### PR TITLE
Update post display settings for non-visibility on both desktop and mobile

### DIFF
--- a/docs/pages/_meta.json
+++ b/docs/pages/_meta.json
@@ -57,8 +57,8 @@
     "title": ""
   },
   "posts": {
-    "type": "page",
-    "display": "hidden"
+    "type": "doc",
+    "display": "Posts"
   },
   "components": {
     "type": "page",

--- a/docs/pages/posts/2020/_meta.json
+++ b/docs/pages/posts/2020/_meta.json
@@ -1,6 +1,6 @@
 {
   "*": {
     "display": "hidden",
-    "type": "page"
+    "type": "doc"
   }
 }

--- a/docs/pages/posts/2021/_meta.json
+++ b/docs/pages/posts/2021/_meta.json
@@ -1,6 +1,6 @@
 {
   "*": {
     "display": "hidden",
-    "type": "page"
+    "type": "doc"
   }
 }

--- a/docs/pages/posts/2022/_meta.json
+++ b/docs/pages/posts/2022/_meta.json
@@ -1,6 +1,6 @@
 {
   "*": {
     "display": "hidden",
-    "type": "page"
+    "type": "doc"
   }
 }

--- a/docs/pages/posts/2023/_meta.json
+++ b/docs/pages/posts/2023/_meta.json
@@ -1,6 +1,6 @@
 {
   "*": {
     "display": "hidden",
-    "type": "page"
+    "type": "doc"
   }
 }

--- a/docs/pages/posts/2024/_meta.json
+++ b/docs/pages/posts/2024/_meta.json
@@ -1,6 +1,6 @@
 {
   "*": {
     "display": "hidden",
-    "type": "page"
+    "type": "doc"
   }
 }

--- a/docs/pages/posts/2025/_meta.json
+++ b/docs/pages/posts/2025/_meta.json
@@ -1,6 +1,6 @@
 {
   "*": {
     "display": "hidden",
-    "type": "page"
+    "type": "doc"
   }
 }

--- a/docs/pages/posts/_meta.json
+++ b/docs/pages/posts/_meta.json
@@ -1,6 +1,6 @@
 {
   "*": {
-    "display": "hidden",
-    "type": "page"
+    "display": "doc",
+    "type": "Post"
   }
 }

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -305,7 +305,6 @@ function Menu({
   className,
   onlyCurrentDocs
 }: MenuProps): ReactElement {
-  return (
     return (
     <ul className={cn(classes.list, className)}>
       {directories.map(item =>

--- a/packages/nextra-theme-docs/src/components/sidebar.tsx
+++ b/packages/nextra-theme-docs/src/components/sidebar.tsx
@@ -306,16 +306,19 @@ function Menu({
   onlyCurrentDocs
 }: MenuProps): ReactElement {
   return (
+    return (
     <ul className={cn(classes.list, className)}>
       {directories.map(item =>
-        !onlyCurrentDocs || item.isUnderCurrentDocsTree ? (
-          item.type === 'menu' ||
-          (item.children && (item.children.length || !item.withIndexPage)) ? (
-            <Folder key={item.name} item={item} anchors={anchors} />
-          ) : (
-            <File key={item.name} item={item} anchors={anchors} />
-          )
-        ) : null
+        // Exclude items marked as hidden, mirroring navbar behaviour
+        item.display === 'hidden' || (onlyCurrentDocs && !item.isUnderCurrentDocsTree)
+          ? null
+          : item.type === 'menu' ||
+            (item.children && (item.children.length || !item.withIndexPage))
+          ? (
+              <Folder key={item.name} item={item} anchors={anchors} />
+            ) : (
+              <File key={item.name} item={item} anchors={anchors} />
+            )
       )}
     </ul>
   )


### PR DESCRIPTION
In nextra-theme-docs/src/components/sidebar.tsx in line 308

Before – the <Menu> component only filtered by the onlyCurrentDocs option:

<ul className={cn(classes.list, className)}>
  {directories.map(item =>
    !onlyCurrentDocs || item.isUnderCurrentDocsTree ? (
      item.type === 'menu' ||
      (item.children && (item.children.length || !item.withIndexPage)) ? (
        <Folder key={item.name} item={item} anchors={anchors} />
      ) : (
        <File key={item.name} item={item} anchors={anchors} />
      )
    ) : null
  )}
</ul>
After –  Now skip any item whose display equals 'hidden', matching navbar logic:

  return (
    <ul className={cn(classes.list, className)}>
      {directories.map(item =>
        // Exclude items marked as hidden, mirroring navbar behaviour
        item.display === 'hidden' || (onlyCurrentDocs && !item.isUnderCurrentDocsTree)
          ? null
          : item.type === 'menu' ||
            (item.children && (item.children.length || !item.withIndexPage))
          ? (
              <Folder key={item.name} item={item} anchors={anchors} />
            ) : (
              <File key={item.name} item={item} anchors={anchors} />
            )
      )}
    </ul>